### PR TITLE
Update action.yml devbox CLI cache location

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       id: cache-devbox-cli
       uses: actions/cache/restore@v4
       with:
-        path: /usr/local/bin/devbox
+        path: ~/.local/bin/devbox
         key: ${{ runner.os }}-${{ runner.arch }}-devbox-cli-${{ env.latest_version }}
 
     - name: Install devbox cli


### PR DESCRIPTION
Update action.yml devbox CLI cache location.

Addresses https://github.com/jetify-com/devbox-install-action/issues/49