### PR TITLE
Add nix version as part of the nix cache key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
   test-action:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14, macos-latest, ubuntu-latest]
+        os: [macos-13, macos-14, macos-latest, ubuntu-latest]
         use-cache: [true, false]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14, macos-latest, ubuntu-latest]
-        use-cache: [true, false]
+        enable-cache: ['true', 'false']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -33,11 +33,14 @@ jobs:
         uses: ./
         with:
           project-path: 'testdata'
-          enable-cache: ${{ matrix.use-cache }}
+          enable-cache: ${{ matrix.enable-cache }}
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-devbox-version:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        enable-cache: ['true', 'false']
     steps:
       - uses: actions/checkout@v4
       - name: Install devbox
@@ -45,10 +48,14 @@ jobs:
         with:
           devbox-version: 0.13.6
           project-path: 'testdata'
+          enable-cache: ${{ matrix.enable-cache }}
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
   
   test-action-with-nix-version:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        enable-cache: ['true', 'false']
     steps:
       - uses: actions/checkout@v4
       - name: Install devbox
@@ -56,6 +63,7 @@ jobs:
         with:
           project-path: 'testdata'
           nix-version: v0.32.3
+          enable-cache: ${{ matrix.enable-cache }}
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,21 +50,6 @@ jobs:
           project-path: 'testdata'
           enable-cache: ${{ matrix.enable-cache }}
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
-  
-  test-action-with-nix-version:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        enable-cache: ['true', 'false']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install devbox
-        uses: ./
-        with:
-          project-path: 'testdata'
-          nix-version: v0.32.3
-          enable-cache: ${{ matrix.enable-cache }}
-          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,15 +36,26 @@ jobs:
           enable-cache: ${{ matrix.use-cache }}
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
-  test-action-with-version:
+  test-action-with-devbox-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.9.1
+          devbox-version: 0.13.6
           project-path: 'testdata'
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
+  
+  test-action-with-nix-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install devbox
+        uses: ./
+        with:
+          project-path: 'testdata'
+          nix-version: v0.32.3
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum:
@@ -54,10 +65,10 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.9.1
+          devbox-version: 0.13.6
           refresh-cli: true
           project-path: 'testdata'
-          sha256-checksum: 'f58202279237b9e0e7d69ef9334c7ca0628db31e5575f105dad6f41a171ebb6a'
+          sha256-checksum: '22a31081df183aab7b8f88a794505c7c0ae217d6314e61b3e0bfe6972b992199'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
 
   test-action-with-sha256-checksum-failure:
@@ -69,7 +80,7 @@ jobs:
         uses: ./
         continue-on-error: true
         with:
-          devbox-version: 0.9.1
+          devbox-version: 0.13.6
           refresh-cli: true
           sha256-checksum: 'bad-sha'
           project-path: 'testdata'
@@ -85,8 +96,8 @@ jobs:
       - name: Install devbox
         uses: ./
         with:
-          devbox-version: 0.9.1
+          devbox-version: 0.13.6
           refresh-cli: true
-          sha256-checksum: 'e7793acf6dadecc6a04eb64d6352665698c75f6c9f59fbe3efee3b04dbec294d'
+          sha256-checksum: '169836de22c41a1c68ac5a43e0514d4021137647c7c08ee8bd921faa430ee286'
           project-path: 'testdata'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Here's an example job with all inputs:
     devbox-version: 0.13.4
     disable-nix-access-token: 'false'
     sha256-checksum: <checksum>
-    nix-version: v0.33
+    nix-version: v0.32.3
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ jobs:
 | devbox-version           | Specify devbox CLI version you want to pin to. Only supports >0.2.2                   | latest                |
 | sha256-checksum          | Specify an explicit checksum for the devbox binary                                    |                       |
 | disable-nix-access-token | Disable configuration of nix access-tokens with the GitHub token used in the workflow | false                 |
-| nix-version              | Specify the version of Nix to install. Default to the latest                          |                       |
 | skip-nix-installation    | Skip the installation of nix                                                          | false                 |
 
 ### Example Configuration
@@ -56,5 +55,4 @@ Here's an example job with all inputs:
     devbox-version: 0.13.4
     disable-nix-access-token: 'false'
     sha256-checksum: <checksum>
-    nix-version: v0.32.3
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
+        uses: jetify-com/devbox-install-action@v0.12.0
 
       - name: Run arbitrary commands
         run: devbox run -- echo "done!"
@@ -48,7 +48,7 @@ Here's an example job with all inputs:
 
 ```
 - name: Install devbox
-  uses: jetify-com/devbox-install-action@v0.11.0
+  uses: jetify-com/devbox-install-action@v0.12.0
   with:
     project-path: 'path-to-folder'
     enable-cache: 'true'

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
 | devbox-version           | Specify devbox CLI version you want to pin to. Only supports >0.2.2                   | latest                |
 | sha256-checksum          | Specify an explicit checksum for the devbox binary                                    |                       |
 | disable-nix-access-token | Disable configuration of nix access-tokens with the GitHub token used in the workflow | false                 |
+| nix-version              | Specify the version of Nix to install. Default to the latest                          |                       |
 | skip-nix-installation    | Skip the installation of nix                                                          | false                 |
 
 ### Example Configuration
@@ -55,4 +56,5 @@ Here's an example job with all inputs:
     devbox-version: 0.13.4
     disable-nix-access-token: 'false'
     sha256-checksum: <checksum>
+    nix-version: v0.33
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,6 @@ inputs:
   skip-nix-installation: # 'true' or 'false'
     description: 'Skip the installation of nix'
     default: 'false'
-  nix-version: # version of nix
-    description: 'Specify the version of Nix to install. Default to the latest'
-    default: ''
 
 runs:
   using: "composite"
@@ -138,8 +135,14 @@ runs:
       uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d  # v16
       with:
         logger: pretty
-        source-tag: ${{ inputs.nix-version }}
         extra-conf: experimental-features = ca-derivations fetch-closure
+
+    - name: Get nix version
+      shell: bash
+      run: |
+        NIX_VERSION_OUTPUT=$(nix --version)
+        NIX_VERSION=$(echo "${NIX_VERSION_OUTPUT}" | awk '{print $NF}')
+        echo "nix-version=$NIX_VERSION" >> $GITHUB_ENV
 
     - name: Mount nix store cache
       id: cache-devbox-nix-store
@@ -154,7 +157,7 @@ runs:
           ~/.nix-profile
           /nix/store
           /nix/var/nix
-        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ inputs.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ env.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
     - name: Install devbox packages
       shell: bash
@@ -167,7 +170,7 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        echo "It is likely that nix has shipped a backwards incompatible change. You can either specify the 'nix-version' flag, or proceed to the actions tab and manually delete the following cache objects:"
+        echo "It is likely that nix has shipped a backwards incompatible change. Proceed to the actions tab and manually delete the following cache objects:"
         gh cache list --key ${{ runner.os }}-${{ runner.arch }}-devbox --json key
 
     - name: Save nix store cache
@@ -182,7 +185,7 @@ runs:
           ~/.nix-profile
           /nix/store
           /nix/var/nix
-        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ inputs.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ env.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
     - name: Restore tar command
       if: inputs.enable-cache == 'true'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   skip-nix-installation: # 'true' or 'false'
     description: 'Skip the installation of nix'
     default: 'false'
+  nix-version: # version of nix
+    description: 'Specify the version of Nix to install. Default to the latest'
+    default: ''
 
 runs:
   using: "composite"
@@ -133,6 +136,7 @@ runs:
       uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d  # v16
       with:
         logger: pretty
+        source-tag: ${{ inputs.nix-version }}
         extra-conf: experimental-features = ca-derivations fetch-closure
 
     - name: Mount nix store cache
@@ -148,7 +152,7 @@ runs:
           ~/.nix-profile
           /nix/store
           /nix/var/nix
-        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ inputs.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
     - name: Install devbox packages
       shell: bash
@@ -167,7 +171,7 @@ runs:
           ~/.nix-profile
           /nix/store
           /nix/var/nix
-        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
+        key: ${{ runner.os }}-${{ runner.arch }}-devbox-nix-store-${{ inputs.nix-version }}-${{ hashFiles(format('{0}/devbox.lock', inputs.project-path)) }}
 
     - name: Restore tar command
       if: inputs.enable-cache == 'true'

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,9 @@ runs:
       if: inputs.refresh-cli == 'false' && steps.cache-devbox-cli.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: ~/.local/bin/devbox
+        path: |
+          ~/.local/bin/devbox
+          /usr/local/bin/devbox
         key: ${{ runner.os }}-${{ runner.arch }}-devbox-cli-${{ env.latest_version }}
 
     - name: Workaround nix store cache permission issue
@@ -158,6 +160,15 @@ runs:
       shell: bash
       run: |
         devbox run --config=${{ inputs.project-path }} -- echo "Packages installed!"
+    
+    - name: List nix store cache on failure
+      shell: bash
+      if: failure()
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "It is likely that nix has shipped a backwards incompatible change. You can either specify the 'nix-version' flag, or proceed to the actions tab and manually delete the following cache objects:"
+        gh cache list --key ${{ runner.os }}-${{ runner.arch }}-devbox --json key
 
     - name: Save nix store cache
       if: inputs.enable-cache == 'true' && steps.cache-devbox-nix-store.outputs.cache-hit != 'true'


### PR DESCRIPTION
Sometimes nix ship backwards incompatible changes, which may result in devbox installation error. The following remedy is considered:

- [x]  Add `nix-version` as part of the Nix cache key
- [x]  Print out additional error message that prompts user to delete cache if needed

Addresses https://github.com/jetify-com/devbox-install-action/issues/64