### PR TITLE
feat(action): Add extra-nix-config input for custom nix.conf settings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,3 +94,17 @@ jobs:
           sha256-checksum: '169836de22c41a1c68ac5a43e0514d4021137647c7c08ee8bd921faa430ee286'
           project-path: 'testdata'
           disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
+
+  test-action-with-extra-nix-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install devbox with extra nix config "user-agent-suffix = test-suffix"
+        uses: ./
+        with:
+          devbox-version: 0.13.6
+          project-path: 'testdata'
+          extra-nix-config: user-agent-suffix = test-suffix
+      - name: Check nix user-agent-suffix config
+        run: |
+          [[ "$(nix config show user-agent-suffix)" == "test-suffix" ]]

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ jobs:
 | sha256-checksum          | Specify an explicit checksum for the devbox binary                                    |                       |
 | disable-nix-access-token | Disable configuration of nix access-tokens with the GitHub token used in the workflow | false                 |
 | skip-nix-installation    | Skip the installation of nix                                                          | false                 |
+| extra-nix-config         | Gets appended to `nix.conf` if passed                                                 |                       |
 
-### Example Configuration
+### Example Configurations
 
-Here's an example job with all inputs:
+Here's an example job with most inputs:
 
 ```
 - name: Install devbox
-  uses: jetify-com/devbox-install-action@v0.12.0
+  uses: jetify-com/devbox-install-action@v0.13.0
   with:
     project-path: 'path-to-folder'
     enable-cache: 'true'
@@ -55,4 +56,13 @@ Here's an example job with all inputs:
     devbox-version: 0.13.4
     disable-nix-access-token: 'false'
     sha256-checksum: <checksum>
+```
+
+#### Usage on a GitHub Enterprise Server
+
+```
+- name: Install devbox
+  uses: jetify-com/devbox-install-action@v0.13.0
+  with:
+    extra-nix-config: access-tokens = my-github-enterprise-server.example.com=${{ github.token }} github.com=${{ secrets.MY_GITHUB_COM_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's an example job with most inputs:
 
 ```
 - name: Install devbox
-  uses: jetify-com/devbox-install-action@v0.13.0
+  uses: jetify-com/devbox-install-action@v0.12.0
   with:
     project-path: 'path-to-folder'
     enable-cache: 'true'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Additionally, it might be necessary to provide a token for your GitHub Enterpris
 
 ```
 - name: Install devbox
-  uses: jetify-com/devbox-install-action@v0.13.0
+  uses: jetify-com/devbox-install-action@v0.12.0
   with:
     extra-nix-config: access-tokens = my-github-enterprise-server.example.com=${{ github.token }} github.com=${{ secrets.MY_GITHUB_COM_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Here's an example job with most inputs:
 
 #### Usage on a GitHub Enterprise Server
 
+On a privately hosted GitHub Enterprise Server, the `github.token` available in the context is not valid for accessing `api.github.com`, 
+which can lead to failures due to the rate-limit for unauthenticated requests. To work around this, you can provide a personal access token
+for `api.github.com` in the `extra-nix-config` input.
+Additionally, it might be necessary to provide a token for your GitHub Enterprise Server, if you are using Nix packages from there.
+
 ```
 - name: Install devbox
   uses: jetify-com/devbox-install-action@v0.13.0

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   skip-nix-installation: # 'true' or 'false'
     description: 'Skip the installation of nix'
     default: 'false'
+  extra-nix-config:
+    description: 'Gets appended to `nix.conf` if passed'
+    default: ''
 
 runs:
   using: "composite"
@@ -126,11 +129,18 @@ runs:
         fi
 
     - name: Configure nix access-tokens
-      if: inputs.disable-nix-access-token == 'false'
+      if: inputs.disable-nix-access-token == 'false' && github.server_url == 'https://github.com'
       shell: bash
       run: |
         mkdir -p ~/.config/nix
         echo "access-tokens = github.com=${{ github.token }}" >> ~/.config/nix/nix.conf
+
+    - name: Configure nix extra config
+      if: inputs.extra-nix-config != ''
+      shell: bash
+      run: |
+        mkdir -p ~/.config/nix
+        echo "${{ inputs.extra-nix-config }}" >> ~/.config/nix/nix.conf
 
     - name: Install nix
       if: inputs.skip-nix-installation == 'false'
@@ -165,7 +175,7 @@ runs:
       shell: bash
       run: |
         devbox run --config=${{ inputs.project-path }} -- echo "Packages installed!"
-    
+
     - name: List nix store cache on failure
       shell: bash
       if: failure()


### PR DESCRIPTION
# Issue

Fixes: #74 

When running actions on self-hosted GitHub Enterprise (GHES) installations, the `github.token` provided is specific to the private GHES instance. This token cannot be used to access resources on `github.com`. While the existing configuration option `disable-nix-access-token` allows users to disable the usage of `github.token` as a Nix access token, this workaround fails once the unauthenticated rate limit for `api.github.com` is exceeded.

Currently, there is no mechanism to configure a custom, working Nix access token for such scenarios. This limitation creates challenges for GHES users who need to:
- Authenticate against `api.github.com` without exceeding rate limits.
- Configure Nix access tokens for other APIs, such as private hosts, when using Nix packages from private repositories.

# Fix

Add a new configuration option `extra-nix-config` that gets appended to `nix.conf` if passed.

This can be used to configure access tokens, and I added this use case as an example to the README.md.