### PR TITLE
Add an optional `nix-package-url` input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,3 +108,38 @@ jobs:
       - name: Check nix user-agent-suffix config
         run: |
           [[ "$(nix config show user-agent-suffix)" == "test-suffix" ]]
+
+  test-nix-versions:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        nix-version: [2.18.0, 2.19.2, 2.24.7, 2.30.2]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install devbox with specific Nix version
+        uses: ./
+        with:
+          project-path: 'testdata'
+          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.nix-version }}/nix-${{ matrix.nix-version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
+          disable-nix-access-token: "${{ github.ref != 'refs/heads/main' }}"
+      - name: Verify Nix version and run devbox commands
+        run: |
+          echo "::group::Nix version"
+          nix --version
+          installed_version=$(nix --version | awk '{print $3}')
+          expected_version="${{ matrix.nix-version }}"
+          if [[ "$installed_version" != "$expected_version" ]]; then
+            echo "ERROR: Expected Nix version $expected_version, but got $installed_version"
+            exit 1
+          fi
+          echo "::endgroup::"
+          echo "::group::Contents of /etc/nix/nix.conf"
+          cat /etc/nix/nix.conf || true
+          echo "::endgroup::"
+          echo "::group::Resolved Nix config"
+          nix show-config --extra-experimental-features nix-command || true
+          echo "::endgroup::"
+          echo "::group::Run devbox commands"
+          devbox run -- echo "Hello from devbox!"
+          echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   extra-nix-config:
     description: 'Gets appended to `nix.conf` if passed'
     default: ''
+  nix-package-url:
+    description: 'URL to a Nix package tarball to install a specific Nix version'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -156,6 +160,7 @@ runs:
         NIX_INSTALLER_START_DAEMON: true
         NIX_INSTALLER_TRUST_RUNNER_USER: true
         NIX_INSTALLER_CHANNELS: nixpkgs=https://nixos.org/channels/nixpkgs-unstable
+        NIX_INSTALLER_NIX_PACKAGE_URL: ${{ inputs.nix-package-url }}
       run: |
         echo "Installing Nix using experimental installer..."
         

--- a/action.yml
+++ b/action.yml
@@ -160,21 +160,26 @@ runs:
         NIX_INSTALLER_START_DAEMON: true
         NIX_INSTALLER_TRUST_RUNNER_USER: true
         NIX_INSTALLER_CHANNELS: nixpkgs=https://nixos.org/channels/nixpkgs-unstable
-        NIX_INSTALLER_NIX_PACKAGE_URL: ${{ inputs.nix-package-url }}
       run: |
         echo "Installing Nix using experimental installer..."
-        
+
+        # Build installer command with optional nix-package-url
+        INSTALL_ARGS="install --no-confirm"
+        if [[ -n "${{ inputs.nix-package-url }}" ]]; then
+          INSTALL_ARGS="$INSTALL_ARGS --nix-package-url ${{ inputs.nix-package-url }}"
+        fi
+
         # Download and run the experimental installer
         curl --proto '=https' --tlsv1.2 -sSf -L https://artifacts.nixos.org/experimental-installer | \
-          sh -s -- install --no-confirm
-        
+          sh -s -- $INSTALL_ARGS
+
         # Source the nix profile to make nix available in current shell
         if [ -f ~/.nix-profile/etc/profile.d/nix.sh ]; then
           source ~/.nix-profile/etc/profile.d/nix.sh
         elif [ -f /etc/profile.d/nix.sh ]; then
           source /etc/profile.d/nix.sh
         fi
-        
+
         # Verify installation
         nix --version
         nix-env --version


### PR DESCRIPTION
Adds a new optional input 'nix-package-url' that allows users to specify
a URL to a Nix package tarball for installing a specific Nix version.
The URL is passed to the experimental installer via the
NIX_INSTALLER_NIX_PACKAGE_URL environment variable.