### PR TITLE
Bump actions/checkout from 4 to 6 with pinned SHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
         enable-cache: ['true', 'false']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox
         uses: ./
         with:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         enable-cache: ['true', 'false']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox
         uses: ./
         with:
@@ -54,7 +54,7 @@ jobs:
   test-action-with-sha256-checksum:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox
         uses: ./
         with:
@@ -67,7 +67,7 @@ jobs:
   test-action-with-sha256-checksum-failure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox
         id: install-devbox
         uses: ./
@@ -85,7 +85,7 @@ jobs:
   test-action-with-sha256-checksum-on-mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox
         uses: ./
         with:
@@ -98,7 +98,7 @@ jobs:
   test-action-with-extra-nix-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install devbox with extra nix config "user-agent-suffix = test-suffix"
         uses: ./
         with:


### PR DESCRIPTION
Pin actions/checkout to commit SHA 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 for security.